### PR TITLE
COBE-11 Configurar Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+		</dependency>
 
 		<!--JJWT library dependencies-->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,23 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!--JJWT library dependencies-->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.10.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.10.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.10.6</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/coopetico/coopeticobackend/controladores/AuthControlador.java
+++ b/src/main/java/com/coopetico/coopeticobackend/controladores/AuthControlador.java
@@ -12,29 +12,42 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.springframework.http.ResponseEntity.ok;
 
+/**
+ * Controlador para los request relacionados con autenticación
+ */
 @RestController
 @RequestMapping("/auth")
 public class AuthControlador {
 
-    @Autowired
+    private final
     AuthenticationManager authenticationManager;
 
-    @Autowired
+    private final
     JwtTokenProvider jwtTokenProvider;
 
-    @Autowired
+    private final
     UsuariosRepositorio users;
 
+    @Autowired
+    public AuthControlador(AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, UsuariosRepositorio users) {
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.users = users;
+    }
+
+    /**
+     * Endpoint para hacer sign in
+     *
+     * @param data Modelo del request de autenticación. Espera los atributos username y password
+     * @return el JWT en caso de un sign in exitoso
+     */
     @PostMapping("/signin")
     public ResponseEntity signin(@RequestBody AuthenticationRequest data) {
         try {
@@ -52,5 +65,15 @@ public class AuthControlador {
         } catch (AuthenticationException e) {
             throw new BadCredentialsException("Invalid username/password supplied");
         }
+    }
+
+    /**
+     * Endpoint de prueba asegurado para probar que el filtro del JWT sirva
+     *
+     * @return Lista con todos los usuarios del sistema
+     */
+    @GetMapping("/usuarios")
+    public List<UsuarioEntidad> todosLosUsuarios() {
+        return users.findAll();
     }
 }

--- a/src/main/java/com/coopetico/coopeticobackend/controladores/AuthControlador.java
+++ b/src/main/java/com/coopetico/coopeticobackend/controladores/AuthControlador.java
@@ -1,0 +1,56 @@
+package com.coopetico.coopeticobackend.controladores;
+
+import com.coopetico.coopeticobackend.entidades.UsuarioEntidad;
+import com.coopetico.coopeticobackend.repositorios.UsuariosRepositorio;
+import com.coopetico.coopeticobackend.security.CustomUserDetails;
+import com.coopetico.coopeticobackend.security.jwt.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthControlador {
+
+    @Autowired
+    AuthenticationManager authenticationManager;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    UsuariosRepositorio users;
+
+    @PostMapping("/signin")
+    public ResponseEntity signin(@RequestBody AuthenticationRequest data) {
+        try {
+            String username = data.getUsername();
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, data.getPassword()));
+            UsuarioEntidad usuarioEntidad = this.users.findById(username).orElseThrow(() -> new UsernameNotFoundException("Username " + username + "not found"));
+            List<String> roles = new CustomUserDetails(usuarioEntidad)
+                    .getAuthorities()
+                    .stream()
+                    .map(SimpleGrantedAuthority::getAuthority)
+                    .collect(Collectors.toList());
+            String token = jwtTokenProvider.createToken(username, roles, usuarioEntidad.getGrupoByIdGrupo().getPkId());
+
+            return ok(token);
+        } catch (AuthenticationException e) {
+            throw new BadCredentialsException("Invalid username/password supplied");
+        }
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/controladores/AuthenticationRequest.java
+++ b/src/main/java/com/coopetico/coopeticobackend/controladores/AuthenticationRequest.java
@@ -1,0 +1,32 @@
+package com.coopetico.coopeticobackend.controladores;
+
+import java.io.Serializable;
+
+public class AuthenticationRequest implements Serializable {
+    private String username;
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public AuthenticationRequest(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public AuthenticationRequest() {
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/excepciones/InvalidJwtAuthenticationException.java
+++ b/src/main/java/com/coopetico/coopeticobackend/excepciones/InvalidJwtAuthenticationException.java
@@ -1,0 +1,9 @@
+package com.coopetico.coopeticobackend.excepciones;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidJwtAuthenticationException extends AuthenticationException {
+    public InvalidJwtAuthenticationException(String e) {
+        super(e);
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetails.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetails.java
@@ -8,26 +8,33 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+/**
+ * Implementación custom de UserDetails para introducir la lógica especial de negocio de los grupos y permisos
+ */
 public class CustomUserDetails implements UserDetails {
     private UsuarioEntidad user;
+    private Collection<SimpleGrantedAuthority> permisos;
+    private String grupoId;
 
     public CustomUserDetails(UsuarioEntidad user) {
         this.user = user;
-    }
-
-    @Override
-    public Collection<SimpleGrantedAuthority> getAuthorities() {
-        return user
+        this.permisos = user
                 .getGrupoByIdGrupo()
                 .getPermisosGruposByPkId()
                 .stream()
                 .map(PermisosGrupoEntidad::getPermisoByPkIdPermisos)
                 .map(permiso -> new SimpleGrantedAuthority(Integer.toString(permiso.getPkId())))
                 .collect(Collectors.toList());
+        this.grupoId = user.getGrupoByIdGrupo().getPkId();
+    }
+
+    @Override
+    public Collection<SimpleGrantedAuthority> getAuthorities() {
+        return this.permisos;
     }
 
     public String getGrupo(){
-        return user.getGrupoByIdGrupo().getPkId();
+        return this.grupoId;
     }
 
     @Override

--- a/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetails.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetails.java
@@ -1,0 +1,62 @@
+package com.coopetico.coopeticobackend.security;
+
+import com.coopetico.coopeticobackend.entidades.PermisosGrupoEntidad;
+import com.coopetico.coopeticobackend.entidades.UsuarioEntidad;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+public class CustomUserDetails implements UserDetails {
+    private UsuarioEntidad user;
+
+    public CustomUserDetails(UsuarioEntidad user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<SimpleGrantedAuthority> getAuthorities() {
+        return user
+                .getGrupoByIdGrupo()
+                .getPermisosGruposByPkId()
+                .stream()
+                .map(PermisosGrupoEntidad::getPermisoByPkIdPermisos)
+                .map(permiso -> new SimpleGrantedAuthority(Integer.toString(permiso.getPkId())))
+                .collect(Collectors.toList());
+    }
+
+    public String getGrupo(){
+        return user.getGrupoByIdGrupo().getPkId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getContrasena();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getPkCorreo();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetailsService.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetailsService.java
@@ -3,23 +3,37 @@ package com.coopetico.coopeticobackend.security;
 import com.coopetico.coopeticobackend.entidades.UsuarioEntidad;
 import com.coopetico.coopeticobackend.repositorios.UsuariosRepositorio;
 import net.bytebuddy.implementation.bytecode.Throw;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+import javax.transaction.Transactional;
 import java.util.Optional;
 
+/**
+ * Implementación custom de UserDetailsService para devolver instancias de nuestro UserDetails custom
+ */
 @Component
 public class CustomUserDetailsService implements UserDetailsService {
 
     private UsuariosRepositorio users;
 
+    @Autowired
     public CustomUserDetailsService(UsuariosRepositorio users) {
         this.users = users;
     }
 
+    /**
+     * Método que se sobrecarga para devolver instancias de CustomUserDetails
+     *
+     * @param username correo del usuario
+     * @return retorna el UserDetails del usuario que se dió por parámetro
+     * @throws UsernameNotFoundException en caso de que el correo no corresponda a ningún usuario
+     */
     @Override
+    @Transactional
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Optional<UsuarioEntidad> usuario = users.findById(username);
         if(usuario.isPresent()){

--- a/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetailsService.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/CustomUserDetailsService.java
@@ -1,0 +1,32 @@
+package com.coopetico.coopeticobackend.security;
+
+import com.coopetico.coopeticobackend.entidades.UsuarioEntidad;
+import com.coopetico.coopeticobackend.repositorios.UsuariosRepositorio;
+import net.bytebuddy.implementation.bytecode.Throw;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private UsuariosRepositorio users;
+
+    public CustomUserDetailsService(UsuariosRepositorio users) {
+        this.users = users;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<UsuarioEntidad> usuario = users.findById(username);
+        if(usuario.isPresent()){
+            return new CustomUserDetails(usuario.get());
+        }
+        else{
+            throw new UsernameNotFoundException("Username: " + username + " not found");
+        }
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/SecretServicio.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/SecretServicio.java
@@ -1,0 +1,73 @@
+package com.coopetico.coopeticobackend.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolver;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import io.jsonwebtoken.impl.TextCodec;
+import io.jsonwebtoken.impl.crypto.MacProvider;
+import io.jsonwebtoken.lang.Assert;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.SecretKey;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class SecretServicio {
+
+    private Map<String, String> secrets = new HashMap<>();
+
+    private SigningKeyResolver signingKeyResolver = new SigningKeyResolverAdapter() {
+        @Override
+        public byte[] resolveSigningKeyBytes(JwsHeader header, Claims claims) {
+            return TextCodec.BASE64.decode(secrets.get(header.getAlgorithm()));
+        }
+    };
+
+    @PostConstruct
+    public void setup() {
+        refreshSecrets();
+    }
+
+    public SigningKeyResolver getSigningKeyResolver() {
+        return signingKeyResolver;
+    }
+
+    public Map<String, String> getSecrets() {
+        return secrets;
+    }
+
+    public void setSecrets(Map<String, String> secrets) {
+        Assert.notNull(secrets);
+        Assert.hasText(secrets.get(SignatureAlgorithm.HS256.getValue()));
+        Assert.hasText(secrets.get(SignatureAlgorithm.HS384.getValue()));
+        Assert.hasText(secrets.get(SignatureAlgorithm.HS512.getValue()));
+
+        this.secrets = secrets;
+    }
+
+    public byte[] getHS256SecretBytes() {
+        return TextCodec.BASE64.decode(secrets.get(SignatureAlgorithm.HS256.getValue()));
+    }
+
+    public byte[] getHS384SecretBytes() {
+        return TextCodec.BASE64.decode(secrets.get(SignatureAlgorithm.HS384.getValue()));
+    }
+
+    public byte[] getHS512SecretBytes() {
+        return TextCodec.BASE64.decode(secrets.get(SignatureAlgorithm.HS512.getValue()));
+    }
+
+    public Map<String, String> refreshSecrets() {
+        SecretKey key = MacProvider.generateKey(SignatureAlgorithm.HS256);
+        secrets.put(SignatureAlgorithm.HS256.getValue(), TextCodec.BASE64.encode(key.getEncoded()));
+        key = MacProvider.generateKey(SignatureAlgorithm.HS384);
+        secrets.put(SignatureAlgorithm.HS384.getValue(), TextCodec.BASE64.encode(key.getEncoded()));
+        key = MacProvider.generateKey(SignatureAlgorithm.HS512);
+        secrets.put(SignatureAlgorithm.HS512.getValue(), TextCodec.BASE64.encode(key.getEncoded()));
+        return secrets;
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/SecretServicio.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/SecretServicio.java
@@ -15,6 +15,10 @@ import javax.crypto.SecretKey;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Servicio que genera keys de tamaño apropiado para el SHA que se esté utilizando
+ */
+@SuppressWarnings("ALL")
 @Service
 public class SecretServicio {
 

--- a/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.coopetico.coopeticobackend.security;
+
+import com.coopetico.coopeticobackend.security.jwt.JwtConfigurer;
+import com.coopetico.coopeticobackend.security.jwt.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new PasswordEncoder() {
+            @Override
+            public String encode(CharSequence rawPassword) {
+                return rawPassword.toString();
+            }
+            @Override
+            public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                return rawPassword.toString().equals(encodedPassword);
+            }
+        };
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        //@formatter:off
+        http
+                .httpBasic().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/auth/signin").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .apply(new JwtConfigurer(jwtTokenProvider));
+        //@formatter:on
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
@@ -81,7 +81,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/auth/signin").permitAll()
                 // El has authority se usa para definir cuáles permisos permiten acceder a ese endpoint
                 .antMatchers("/auth/usuarios").hasAuthority("1")
-                .anyRequest().authenticated()
+                .anyRequest().permitAll()
                 .and()
                 // Se aplica el filtro de los JWT
                 .apply(new JwtConfigurer(jwtTokenProvider));

--- a/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/SecurityConfig.java
@@ -3,28 +3,53 @@ package com.coopetico.coopeticobackend.security;
 import com.coopetico.coopeticobackend.security.jwt.JwtConfigurer;
 import com.coopetico.coopeticobackend.security.jwt.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+/**
+ * Clase de configuración de Spring Security
+ */
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 
-    @Autowired
+    private final
     JwtTokenProvider jwtTokenProvider;
 
+    private final
+    UserDetailsService userDetailsService;
+
+    @Autowired
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider, @Qualifier("customUserDetailsService") UserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    /**
+     * Crea el bean de Authentication Manager
+     *
+     * @return la instancia de AuthenticationManager
+     */
     @Bean
     @Override
     public AuthenticationManager authenticationManagerBean() throws Exception {
         return super.authenticationManagerBean();
     }
 
+    /**
+     * Configura el bean de PasswordEncoder que se utilizará para encriptar.
+     *
+     * @return la instancia del PasswordEncoder
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new PasswordEncoder() {
@@ -39,19 +64,26 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         };
     }
 
+    /**
+     *  Método principal de configuración donde se incluyen las reglas de autenticación y acceso a los endpoints
+     *
+     * @param http instancia de seguridad
+     */
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        //@formatter:off
         http
                 .httpBasic().disable()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
+                // Aquí se agregan las reglas de autenticación para acceder a los endpoint
                 .antMatchers("/auth/signin").permitAll()
+                // El has authority se usa para definir cuáles permisos permiten acceder a ese endpoint
+                .antMatchers("/auth/usuarios").hasAuthority("1")
                 .anyRequest().authenticated()
                 .and()
+                // Se aplica el filtro de los JWT
                 .apply(new JwtConfigurer(jwtTokenProvider));
-        //@formatter:on
     }
 }

--- a/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtConfigurer.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtConfigurer.java
@@ -1,10 +1,14 @@
 package com.coopetico.coopeticobackend.security.jwt;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * Configura el filtro general para que utilice el JwtProvider
+ */
 public class JwtConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private JwtTokenProvider jwtTokenProvider;
@@ -13,8 +17,12 @@ public class JwtConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilt
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
+    /**
+     * Método a sobreescribir para setear la configuración del filtro
+     * @param http Instancia de seguridad a la que se le va a agregar el filtro
+     */
     @Override
-    public void configure(HttpSecurity http) throws Exception {
+    public void configure(HttpSecurity http) {
         JwtTokenFilter customFilter = new JwtTokenFilter(jwtTokenProvider);
         http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }

--- a/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtConfigurer.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtConfigurer.java
@@ -1,0 +1,21 @@
+package com.coopetico.coopeticobackend.security.jwt;
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JwtConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    public JwtConfigurer(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        JwtTokenFilter customFilter = new JwtTokenFilter(jwtTokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenFilter.java
@@ -1,0 +1,34 @@
+package com.coopetico.coopeticobackend.security.jwt;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class JwtTokenFilter extends GenericFilterBean {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    public JwtTokenFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        String token = jwtTokenProvider.resolveToken((HttpServletRequest) req);
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication auth = token != null ? jwtTokenProvider.getAuthentication(token) : null;
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(req, res);
+    }
+
+}

--- a/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenProvider.java
@@ -1,12 +1,12 @@
 package com.coopetico.coopeticobackend.security.jwt;
 
+import com.coopetico.coopeticobackend.excepciones.InvalidJwtAuthenticationException;
 import com.coopetico.coopeticobackend.security.SecretServicio;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.InvalidKeyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,25 +16,39 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 
+/**
+ * Clase con lógica para crear, validar y procesar JWTs
+ */
 @Component
 public class JwtTokenProvider {
 
+    /**
+     * Tiempo de validez del token
+     */
     @Value("${security.jwt.token.expire-length:3600000}")
     private long validityInMilliseconds = 3600000; // 1h
 
-    @Qualifier("customUserDetailsService")
-    @Autowired
-    private UserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
+
+    private final SecretServicio secretkey;
 
     @Autowired
-    private SecretServicio secretkey;
+    public JwtTokenProvider(@Qualifier("customUserDetailsService") UserDetailsService userDetailsService, SecretServicio secretkey) {
+        this.userDetailsService = userDetailsService;
+        this.secretkey = secretkey;
+    }
 
+    /**
+     * Crea el token de JWT con los claims deseados de usuario, rol, permisos, tiempo de creación y tiempo de expiración
+     * @param username correo del usuario
+     * @param permisos lista de permisos del usuario
+     * @param rol rol del usuario
+     * @return retorna String que representa el JWT
+     */
     public String createToken(String username, List<String> permisos, String rol) {
 
         Claims claims = Jwts.claims().setSubject(username);
@@ -52,34 +66,54 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public Authentication getAuthentication(String token) {
+    /**
+     * Crea una instancia de Authentication a partir de la información del usuario que viene el token
+     *
+     * @param token JWT que envió el cliente
+     * @return instancia de Authentication para hacer lógica de autenticación
+     */
+    Authentication getAuthentication(String token) {
         UserDetails userDetails = this.userDetailsService.loadUserByUsername(getUsername(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
-    public String getUsername(String token) {
+    /**
+     * Obtiene el correo del usuario por medio de decodificar el token
+     *
+     * @param token token que envió el cliente
+     * @return retorna el correo que venía en el token
+     */
+    private String getUsername(String token) {
         return Jwts.parser().setSigningKey(secretkey.getHS256SecretBytes()).parseClaimsJws(token).getBody().getSubject();
     }
 
-    public String resolveToken(HttpServletRequest req) {
+    /**
+     * Extrae el token del header del request del cliente
+     *
+     * @param req request del cliente
+     * @return String que representa el token JWT
+     */
+    String resolveToken(HttpServletRequest req) {
         String bearerToken = req.getHeader("Authorization");
         if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7, bearerToken.length());
+            return bearerToken.substring(7);
         }
         return null;
     }
 
-    public boolean validateToken(String token) {
+    /**
+     * Valida el token al decodificarlo con el secret key y verificar el tiempo de expiración
+     *
+     * @param token token JWT
+     * @return retorna true si es un token válido o false si no
+     */
+    boolean validateToken(String token) {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretkey.getHS256SecretBytes()).parseClaimsJws(token);
-
-            if (claims.getBody().getExpiration().before(new Date())) {
-                return false;
-            }
-
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new InvalidKeyException("Expired or invalid JWT token");
+            return !claims.getBody().getExpiration().before(new Date());
+        }
+        catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidJwtAuthenticationException("Expired or invalid JWT token");
         }
     }
 

--- a/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/coopetico/coopeticobackend/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.coopetico.coopeticobackend.security.jwt;
+
+import com.coopetico.coopeticobackend.security.SecretServicio;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.InvalidKeyException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${security.jwt.token.expire-length:3600000}")
+    private long validityInMilliseconds = 3600000; // 1h
+
+    @Qualifier("customUserDetailsService")
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Autowired
+    private SecretServicio secretkey;
+
+    public String createToken(String username, List<String> permisos, String rol) {
+
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("permisos", permisos);
+        claims.put("rol", rol);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        return Jwts.builder()//
+                .setClaims(claims)//
+                .setIssuedAt(now)//
+                .setExpiration(validity)//
+                .signWith(SignatureAlgorithm.HS256, secretkey.getHS256SecretBytes())//
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = this.userDetailsService.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    public String getUsername(String token) {
+        return Jwts.parser().setSigningKey(secretkey.getHS256SecretBytes()).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest req) {
+        String bearerToken = req.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretkey.getHS256SecretBytes()).parseClaimsJws(token);
+
+            if (claims.getBody().getExpiration().before(new Date())) {
+                return false;
+            }
+
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new InvalidKeyException("Expired or invalid JWT token");
+        }
+    }
+
+}


### PR DESCRIPTION
Se configuró Spring Security para generar tokens JWT con los permisos, el rol y el nombre de usuario en el payload. Se creó un endpoint auth/signin para probar el signin y que devuelva el token. Ahorita el passwordEncoder no hace nada, entonces las contraseñas en la base de datos pueden estar en plain text para probar